### PR TITLE
Outputting colored text under cmd.exe

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
 const testing = std.testing;
-usingnamespace @import("writer.zig");
+const writer = @import("writer.zig");
+const Fg = writer.Fg;
+const OutputWriter = writer.OutputWriter;
 
 /// Caller must free memory.
 pub fn askString(allocator: *std.mem.Allocator, prompt: []const u8, max_size: usize) ![]u8 {
     const in = std.io.getStdIn().reader();
-    const out = makeOutputWriter(std.io.getStdOut());
+    const out = OutputWriter.init(std.io.getStdOut());
 
     try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt });
 
@@ -15,7 +17,7 @@ pub fn askString(allocator: *std.mem.Allocator, prompt: []const u8, max_size: us
 
 /// Caller must free memory. Max size is recommended to be a high value, like 512.
 pub fn askDirPath(allocator: *std.mem.Allocator, prompt: []const u8, max_size: usize) ![]u8 {
-    const out = makeOutputWriter(std.io.getStdOut());
+    const out = OutputWriter.init(std.io.getStdOut());
 
     while (true) {
         const path = try askString(allocator, prompt, max_size);
@@ -38,7 +40,7 @@ pub fn askDirPath(allocator: *std.mem.Allocator, prompt: []const u8, max_size: u
 
 pub fn askBool(prompt: []const u8) !bool {
     const in = std.io.getStdIn().reader();
-    const out = makeOutputWriter(std.io.getStdOut());
+    const out = OutputWriter.init(std.io.getStdOut());
 
     var buffer: [1]u8 = undefined;
 
@@ -60,7 +62,7 @@ pub fn askBool(prompt: []const u8) !bool {
 
 pub fn askSelectOne(prompt: []const u8, comptime options: type) !options {
     const in = std.io.getStdIn().reader();
-    const out = makeOutputWriter(std.io.getStdOut());
+    const out = OutputWriter.init(std.io.getStdOut());
 
     try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.DarkGray, " (select one)", "\n\n" });
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,30 +3,6 @@ const ansi = @import("ansi.zig");
 const testing = std.testing;
 
 const windows = std.os.windows;
-// https://docs.microsoft.com/en-us/windows/console/getconsolemode
-extern "kernel32" fn GetConsoleMode(h_console: windows.HANDLE, mode: *windows.DWORD) callconv(if (std.builtin.arch == .i386) .Stdcall else .C) windows.BOOL;
-
-pub fn terminalSupportsAnsiColor(h_console: std.os.fd_t) bool {
-    if (std.builtin.os.tag == .windows) {
-        var mode: windows.DWORD = 0;
-        if (GetConsoleMode(h_console, &mode) != windows.FALSE) {
-            const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
-            if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0)
-                return true;            
-        } 
-
-        // Check if we run under ConEmu
-        const wstr = std.unicode.utf8ToUtf16LeStringLiteral;
-        if (std.os.getenvW(wstr("ConEmuANSI"))) |val| {
-            if (std.mem.eql(u16, val, wstr("ON")))
-                return true;
-        }
-
-        return false;
-    }
-
-    return true;
-}
 
 const Fg = enum {
     Black,
@@ -37,7 +13,6 @@ const Fg = enum {
     Magenta,
     Cyan,
     LightGray,
-    Default,
     DarkGray,
     LightRed,
     LightGreen,
@@ -57,7 +32,6 @@ const Fg = enum {
             Fg.Magenta => ansi.Foreground(ansi.Magenta),
             Fg.Cyan => ansi.Foreground(ansi.Cyan),
             Fg.LightGray => ansi.Foreground(ansi.LightGray),
-            Fg.Default => ansi.Foreground(ansi.Default),
             Fg.DarkGray => ansi.Foreground(ansi.DarkGray),
             Fg.LightRed => ansi.Foreground(ansi.LightRed),
             Fg.LightGreen => ansi.Foreground(ansi.LightGreen),
@@ -66,6 +40,32 @@ const Fg = enum {
             Fg.LightMagenta => ansi.Foreground(ansi.LightMagenta),
             Fg.LightCyan => ansi.Foreground(ansi.LightCyan),
             Fg.White => ansi.Foreground(ansi.White),
+        };
+    }
+
+    fn winConAttribValue(self: Fg) windows.DWORD {
+        const FOREGROUND_BLUE      = 0x0001; // text color contains blue.
+        const FOREGROUND_GREEN     = 0x0002; // text color contains green.
+        const FOREGROUND_RED       = 0x0004; // text color contains red.
+        const FOREGROUND_INTENSITY = 0x0008; // text color is intensified.
+
+        return switch (self) {
+            Fg.Black => 0,
+            Fg.Red => FOREGROUND_RED,
+            Fg.Green => FOREGROUND_GREEN,
+            Fg.Yellow => FOREGROUND_GREEN | FOREGROUND_RED,
+            Fg.Blue => FOREGROUND_BLUE,
+            Fg.Magenta => FOREGROUND_RED | FOREGROUND_BLUE,
+            Fg.Cyan => FOREGROUND_GREEN | FOREGROUND_BLUE,
+            Fg.LightGray => FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE,
+            Fg.DarkGray => FOREGROUND_INTENSITY,
+            Fg.LightRed => FOREGROUND_RED | FOREGROUND_INTENSITY,
+            Fg.LightGreen => FOREGROUND_GREEN | FOREGROUND_INTENSITY,
+            Fg.LightYellow => FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY,
+            Fg.LightBlue => FOREGROUND_BLUE | FOREGROUND_INTENSITY,
+            Fg.LightMagenta => FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY,
+            Fg.LightCyan => FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY,
+            Fg.White => FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY,
         };
     }
 };
@@ -79,7 +79,7 @@ const ColorWriter = struct {
     pub fn init(output: std.fs.File) Self {
         return Self {
             .writer = output.writer(),
-            .have_color = terminalSupportsAnsiColor(output.handle),
+            .have_color = Self.terminalSupportsAnsiColor(output.handle),
         };
     }
 
@@ -104,6 +104,30 @@ const ColorWriter = struct {
 
     pub fn writeAll(self: *const Self, val: []const u8) !void {
         try self.writer.writeAll(val);
+    }
+   
+    extern "kernel32" fn GetConsoleMode(h_console: windows.HANDLE, mode: *windows.DWORD) callconv(if (std.builtin.arch == .i386) .Stdcall else .C) windows.BOOL;    
+
+    pub fn terminalSupportsAnsiColor(h_console: std.os.fd_t) bool {
+        if (std.builtin.os.tag == .windows) {
+            var mode: windows.DWORD = 0;
+            if (Self.GetConsoleMode(h_console, &mode) != windows.FALSE) {
+                const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
+                if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0)
+                    return true;            
+            } 
+
+            // Check if we run under ConEmu
+            const wstr = std.unicode.utf8ToUtf16LeStringLiteral;
+            if (std.os.getenvW(wstr("ConEmuANSI"))) |val| {
+                if (std.mem.eql(u16, val, wstr("ON")))
+                    return true;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,14 +2,116 @@ const std = @import("std");
 const ansi = @import("ansi.zig");
 const testing = std.testing;
 
+const windows = std.os.windows;
+// https://docs.microsoft.com/en-us/windows/console/getconsolemode
+extern "kernel32" fn GetConsoleMode(h_console: windows.HANDLE, mode: *windows.DWORD) callconv(if (std.builtin.arch == .i386) .Stdcall else .C) windows.BOOL;
+
+pub fn terminalSupportsAnsiColor(h_console: std.os.fd_t) bool {
+    if (std.builtin.os.tag == .windows) {
+        var mode: windows.DWORD = 0;
+        if (GetConsoleMode(h_console, &mode) != windows.FALSE) {
+            const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
+            if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0)
+                return true;            
+        } 
+
+        // Check if we run under ConEmu
+        const wstr = std.unicode.utf8ToUtf16LeStringLiteral;
+        if (std.os.getenvW(wstr("ConEmuANSI"))) |val| {
+            if (std.mem.eql(u16, val, wstr("ON")))
+                return true;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+const Fg = enum {
+    Reset,
+
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    LightGray,
+    Default,
+    DarkGray,
+    LightRed,
+    LightGreen,
+    LightYellow,
+    LightBlue,
+    LightMagenta,
+    LightCyan,
+    White,
+
+    fn ansiValue(self: Fg) []const u8 {
+        return switch (self) {
+            Fg.Reset => ansi.Reset(),
+            Fg.Black => ansi.Foreground(ansi.Black),
+            Fg.Red => ansi.Foreground(ansi.Red),
+            Fg.Green => ansi.Foreground(ansi.Green),
+            Fg.Yellow => ansi.Foreground(ansi.Yellow),
+            Fg.Blue => ansi.Foreground(ansi.Blue),
+            Fg.Magenta => ansi.Foreground(ansi.Magenta),
+            Fg.Cyan => ansi.Foreground(ansi.Cyan),
+            Fg.LightGray => ansi.Foreground(ansi.LightGray),
+            Fg.Default => ansi.Foreground(ansi.Default),
+            Fg.DarkGray => ansi.Foreground(ansi.DarkGray),
+            Fg.LightRed => ansi.Foreground(ansi.LightRed),
+            Fg.LightGreen => ansi.Foreground(ansi.LightGreen),
+            Fg.LightYellow => ansi.Foreground(ansi.LightYellow),
+            Fg.LightBlue => ansi.Foreground(ansi.LightBlue),
+            Fg.LightMagenta => ansi.Foreground(ansi.LightMagenta),
+            Fg.LightCyan => ansi.Foreground(ansi.LightCyan),
+            Fg.White => ansi.Foreground(ansi.White),
+        };
+    }
+};
+
+const ColorWriter = struct {
+    const Self = @This();
+
+    writer: std.fs.File.Writer,
+    have_color: bool,
+
+    pub fn init(output: std.fs.File) Self {
+        return Self {
+            .writer = output.writer(),
+            .have_color = terminalSupportsAnsiColor(output.handle),
+        };
+    }
+
+    pub fn writeSeq(self: *const Self, seq: anytype) !void {
+        comptime var i: usize = 0;
+        inline while (i < seq.len) : (i += 1) {
+            const val = seq[i];
+            switch (@TypeOf(val)) {
+                Fg => {
+                    if (self.have_color) {
+                        try self.writeAll(val.ansiValue());
+                    }
+                },
+                else => try self.writeAll(val),
+            }
+        }
+    }
+
+    pub fn writeAll(self: *const Self, val: []const u8) !void {
+        try self.writer.writeAll(val);
+    }
+};
+
 /// Caller must free memory.
 pub fn askString(allocator: *std.mem.Allocator, prompt: []const u8, max_size: usize) ![]u8 {
     const in = std.io.getStdIn().reader();
-    const out = std.io.getStdOut().writer();
+    const out = ColorWriter.init(std.io.getStdOut());
 
-    try out.writeAll(ansi.Foreground(ansi.Cyan) ++ "? " ++ ansi.Foreground(ansi.White));
-    try out.writeAll(prompt);
-    try out.writeAll(ansi.Foreground(ansi.DarkGray) ++ " > " ++ ansi.Reset());
+    try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.Reset });
 
     const result = try in.readUntilDelimiterAlloc(allocator, '\n', max_size);
     return if (std.mem.endsWith(u8, result, "\r")) result[0..(result.len - 1)] else result;
@@ -17,18 +119,18 @@ pub fn askString(allocator: *std.mem.Allocator, prompt: []const u8, max_size: us
 
 /// Caller must free memory. Max size is recommended to be a high value, like 512.
 pub fn askDirPath(allocator: *std.mem.Allocator, prompt: []const u8, max_size: usize) ![]u8 {
-    const out = std.io.getStdOut().writer();
+    const out = ColorWriter.init(std.io.getStdOut());
 
     while (true) {
         const path = try askString(allocator, prompt, max_size);
         if (!std.fs.path.isAbsolute(path)) {
-            try out.writeAll(ansi.Foreground(ansi.Red) ++ "Error: Invalid directory, please try again.\n\n" ++ ansi.Reset());
+            try out.writeSeq(.{ Fg.Red, "Error: Invalid directory, please try again.\n\n", Fg.Reset });
             allocator.free(path);
             continue;
         }
 
         var dir = std.fs.cwd().openDir(path, std.fs.Dir.OpenDirOptions{}) catch {
-            try out.writeAll(ansi.Foreground(ansi.Red) ++ "Error: Invalid directory, please try again.\n\n" ++ ansi.Reset());
+            try cw.writeSequence(.{ Fg.Red, "Error: Invalid directory, please try again.\n\n", Fg.Reset});
             allocator.free(path);
             continue;
         };
@@ -40,14 +142,12 @@ pub fn askDirPath(allocator: *std.mem.Allocator, prompt: []const u8, max_size: u
 
 pub fn askBool(prompt: []const u8) !bool {
     const in = std.io.getStdIn().reader();
-    const out = std.io.getStdOut().writer();
+    const out = ColorWriter.init(std.io.getStdOut());
 
     var buffer: [1]u8 = undefined;
 
     while (true) {
-        try out.writeAll(ansi.Foreground(ansi.Cyan) ++ "? " ++ ansi.Foreground(ansi.White));
-        try out.writeAll(prompt);
-        try out.writeAll(ansi.Foreground(ansi.DarkGray) ++ " (y/n) > " ++ ansi.Reset());
+        try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.DarkGray, " (y/n) > ", Fg.Reset });
 
         const read = in.read(&buffer) catch continue;
         try in.skipUntilDelimiterOrEof('\n');
@@ -64,29 +164,24 @@ pub fn askBool(prompt: []const u8) !bool {
 
 pub fn askSelectOne(prompt: []const u8, comptime options: type) !options {
     const in = std.io.getStdIn().reader();
-    const out = std.io.getStdOut().writer();
+    const out = ColorWriter.init(std.io.getStdOut());
 
-    try out.writeAll(ansi.Foreground(ansi.Cyan) ++ "? " ++ ansi.Foreground(ansi.White));
-    try out.writeAll(prompt);
-    try out.writeAll(ansi.Foreground(ansi.DarkGray) ++ " (select one)" ++ ansi.Reset() ++ "\n\n");
+    try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.DarkGray, " (select one)", Fg.Reset, "\n\n" });
 
     comptime var max_size: usize = 0;
     inline for (@typeInfo(options).Enum.fields) |option| {
-        try out.writeAll("  - ");
-        try out.writeAll(option.name);
-        try out.writeAll("\n");
-
+        try out.writeSeq(.{ "  - ", option.name, "\n" });
         if (option.name.len > max_size) max_size = option.name.len;
     }
 
     while (true) {
         var buffer: [max_size + 1]u8 = undefined;
 
-        try out.writeAll(ansi.Foreground(ansi.DarkGray) ++ "\n>" ++ ansi.Reset() ++ " ");
+        try out.writeSeq(.{ Fg.DarkGray, "\n>", Fg.Reset, " " });
 
         var result = (in.readUntilDelimiterOrEof(&buffer, '\n') catch {
             try in.skipUntilDelimiterOrEof('\n');
-            try out.writeAll(ansi.Foreground(ansi.Red) ++ "Error: Invalid option, please try again.\n" ++ ansi.Reset());
+            try out.writeSeq(.{ Fg.Red, "Error: Invalid option, please try again.\n", Fg.Reset });
             continue;
         }) orelse return error.EndOfStream;
         result = if (std.mem.endsWith(u8, result, "\r")) result[0..(result.len - 1)] else result;
@@ -96,7 +191,7 @@ pub fn askSelectOne(prompt: []const u8, comptime options: type) !options {
                 return @intToEnum(options, option.value);
         // return option.value;
 
-        try out.writeAll(ansi.Foreground(ansi.Red) ++ "Error: Invalid option, please try again.\n" ++ ansi.Reset());
+        try out.writeSeq(.{ Fg.Red, "Error: Invalid option, please try again.\n", Fg.Reset });
     }
 
     // return undefined;

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -1,0 +1,243 @@
+const std = @import("std");
+const ansi = @import("ansi.zig");
+const Writer = std.fs.File.Writer;
+
+const targeting_windows = (std.builtin.os.tag == .windows);
+const windows = if (targeting_windows) std.os.windows else undefined;
+
+pub const Fg = enum {
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    LightGray,
+    DarkGray,
+    LightRed,
+    LightGreen,
+    LightYellow,
+    LightBlue,
+    LightMagenta,
+    LightCyan,
+    White,
+};
+
+/// Ignores color specifications
+const PlainWriter = struct {
+    writer: Writer,
+
+    pub fn init(writer: Writer) PlainWriter {
+        return PlainWriter{  
+            .writer = writer,
+        };
+    }
+
+    pub fn writeSeq(self: *const PlainWriter, seq: anytype) !void {
+        comptime var i: usize = 0;
+        inline while (i < seq.len) : (i += 1) {
+            const val = seq[i];
+            switch (@TypeOf(val)) {
+                Fg => { },
+                else => {
+                    try self.writer.writeAll(val);
+                }
+            }
+        }
+    }
+};
+
+/// Handles color using ANSI vTerm sequences
+const AnsiWriter = struct {
+    writer: Writer,
+
+    pub fn init(writer: Writer) AnsiWriter {
+        return AnsiWriter{  
+            .writer = writer,
+        };
+    }
+ 
+    pub fn writeSeq(self: *const AnsiWriter, seq: anytype) !void {
+        comptime var i: usize = 0;
+        comptime var do_reset = false;
+        inline while (i < seq.len) : (i += 1) {
+            const val = seq[i];
+            switch (@TypeOf(val)) {
+                Fg => {
+                    try self.writer.writeAll(AnsiWriter.fgSequence(val));
+                    do_reset = true;
+                },
+                else => {
+                    try self.writer.writeAll(val);
+                }
+            }
+        }
+        if (do_reset) {
+            try self.writer.writeAll(ansi.Reset());
+        }
+    }
+
+    fn fgSequence(fg: Fg) []const u8 {
+        return switch (fg) {
+            Fg.Black => ansi.Foreground(ansi.Black),
+            Fg.Red => ansi.Foreground(ansi.Red),
+            Fg.Green => ansi.Foreground(ansi.Green),
+            Fg.Yellow => ansi.Foreground(ansi.Yellow),
+            Fg.Blue => ansi.Foreground(ansi.Blue),
+            Fg.Magenta => ansi.Foreground(ansi.Magenta),
+            Fg.Cyan => ansi.Foreground(ansi.Cyan),
+            Fg.LightGray => ansi.Foreground(ansi.LightGray),
+            Fg.DarkGray => ansi.Foreground(ansi.DarkGray),
+            Fg.LightRed => ansi.Foreground(ansi.LightRed),
+            Fg.LightGreen => ansi.Foreground(ansi.LightGreen),
+            Fg.LightYellow => ansi.Foreground(ansi.LightYellow),
+            Fg.LightBlue => ansi.Foreground(ansi.LightBlue),
+            Fg.LightMagenta => ansi.Foreground(ansi.LightMagenta),
+            Fg.LightCyan => ansi.Foreground(ansi.LightCyan),
+            Fg.White => ansi.Foreground(ansi.White),
+        };        
+    }
+};
+
+/// Coloring text using Windows Console API
+const WinConWriter = struct {
+    writer: Writer,
+    orig_attribs: windows.DWORD,
+
+    pub fn init(writer: Writer) WinConWriter {
+        var tmp: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+        _ = WinConWriter.GetConsoleScreenBufferInfo(writer.context.handle, &tmp);
+
+        return WinConWriter {
+            .writer = writer,
+            .orig_attribs = tmp.wAttributes,
+        };
+    }
+
+    pub fn writeSeq(self: *const WinConWriter, seq: anytype) !void {
+        const handle = self.writer.context.handle;
+
+        comptime var i: usize = 0;
+        comptime var do_reset = false;
+        inline while (i < seq.len) : (i += 1) {
+            const val = seq[i];
+            switch (@TypeOf(val)) {
+                Fg => {
+                    const foreground_mask = @as(windows.WORD, 0b1111);
+                    const new_attrib = (self.orig_attribs & (~foreground_mask)) | WinConWriter.winConAttribValue(val);
+                    _ = WinConWriter.SetConsoleTextAttribute(handle, new_attrib);
+                    do_reset = true;
+                },
+                else => try self.writer.writeAll(val),
+            }
+        }
+        if (do_reset)
+            _ = WinConWriter.SetConsoleTextAttribute(handle, self.orig_attribs);
+    }    
+
+    fn winConAttribValue(fg: Fg) windows.DWORD {
+        const blue      = windows.FOREGROUND_BLUE;
+        const green     = windows.FOREGROUND_GREEN;
+        const red       = windows.FOREGROUND_RED;
+        const bright    = windows.FOREGROUND_INTENSITY;
+
+        return switch (fg) {
+            Fg.Black => 0,
+            Fg.Red => red,
+            Fg.Green => green,
+            Fg.Yellow => green | red,
+            Fg.Blue => blue,
+            Fg.Magenta => red | blue,
+            Fg.Cyan => green | blue,
+            Fg.LightGray => red | green | blue,
+            Fg.DarkGray => bright,
+            Fg.LightRed => red | bright,
+            Fg.LightGreen => green | bright,
+            Fg.LightYellow => red | green | bright,
+            Fg.LightBlue => blue | bright,
+            Fg.LightMagenta => red | blue | bright,
+            Fg.LightCyan => blue | green | bright,
+            Fg.White => red | green | blue | bright,
+        };
+    }   
+
+    extern "kernel32" fn GetConsoleMode(h_console: windows.HANDLE, mode: *windows.DWORD) callconv(windows.WINAPI) windows.BOOL;
+    extern "kernel32" fn GetConsoleScreenBufferInfo(h_console: windows.HANDLE, info: *windows.CONSOLE_SCREEN_BUFFER_INFO) callconv(windows.WINAPI) windows.BOOL;
+    extern "kernel32" fn SetConsoleTextAttribute(h_console: windows.HANDLE, attrib: windows.DWORD) callconv(windows.WINAPI) windows.BOOL;     
+};
+
+fn targetWriterImpl() type {
+    if (targeting_windows) {
+        return union(enum) {
+            Plain: PlainWriter,
+            Ansi: AnsiWriter,
+            WinCon: WinConWriter,
+        };
+    } else {
+        return union(enum) {
+            Plain: PlainWriter,
+            Ansi: AnsiWriter,
+        };
+    }
+}
+
+const WriterImpl = targetWriterImpl();
+
+const OutputWriter = struct {
+    impl: WriterImpl,
+
+    pub fn writeSeq(self: *const OutputWriter, seq: anytype) !void {
+        if (targeting_windows) {
+            switch (self.impl) {
+                WriterImpl.Plain => |w| try w.writeSeq(seq),
+                WriterImpl.Ansi => |w| try w.writeSeq(seq),
+                WriterImpl.WinCon => |w| try w.writeSeq(seq),
+            }
+        } else {
+            switch (self.impl) {
+                WriterImpl.Plain => |w| try w.writeSeq(seq),
+                WriterImpl.Ansi => |w| try w.writeSeq(seq),
+            }
+        }
+    }
+};
+
+extern "kernel32" fn GetConsoleMode(h: windows.HANDLE, m: *windows.DWORD) callconv(windows.WINAPI) windows.BOOL;
+
+pub fn makeOutputWriter(output: std.fs.File) OutputWriter {
+    if (targeting_windows) {
+        var mode: windows.DWORD = 0;
+        if (GetConsoleMode(output.handle, &mode) != windows.FALSE) {
+            const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
+            if (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0) {
+                return OutputWriter{
+                    .impl = WriterImpl{ .Ansi = AnsiWriter.init(output.writer()) },
+                };
+            }
+        } else {
+            return OutputWriter{
+                .impl = WriterImpl{ .Plain = PlainWriter.init(output.writer()) },
+            };
+        }
+
+        // Check if we run under ConEmu
+        const wstr = std.unicode.utf8ToUtf16LeStringLiteral;
+        if (std.os.getenvW(wstr("ConEmuANSI"))) |val| {
+            if (std.mem.eql(u16, val, wstr("ON"))) {
+                return OutputWriter{
+                    .impl = WriterImpl{ .Ansi = AnsiWriter.init(output.writer()) },
+                };
+            }
+        }
+
+        return OutputWriter{
+            .impl = WriterImpl{ .WinCon = WinConWriter.init(output.writer()) },
+        };
+    } else {
+        // TODO: Examine isatty() & env(TERM) to make a decision
+        return OutputWriter{
+            .impl = WriterImpl{ .Ansi = AnsiWriter.init(output.writer()) },
+        };
+    }
+}

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -106,7 +106,7 @@ const AnsiWriter = struct {
 };
 
 /// Coloring text using Windows Console API
-const WinConWriter = struct {
+const WinConWriter = if (targeting_windows) struct {
     writer: Writer,
     orig_attribs: windows.DWORD,
 
@@ -166,7 +166,7 @@ const WinConWriter = struct {
             Fg.White => red | green | blue | bright,
         };
     }   
-};
+} else undefined;
 
 const WriterImpl = if (targeting_windows) union(enum) {
     Plain: PlainWriter,

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -3,12 +3,12 @@ const ansi = @import("ansi.zig");
 const Writer = std.fs.File.Writer;
 
 const targeting_windows = (std.builtin.os.tag == .windows);
-const windows = if (targeting_windows) std.os.windows else undefined;
-const wincon = if (targeting_windows) struct {
+const windows = std.os.windows;
+const wincon = struct {
     pub extern "kernel32" fn GetConsoleMode(h_console: windows.HANDLE, mode: *windows.DWORD) callconv(windows.WINAPI) windows.BOOL;
     pub extern "kernel32" fn GetConsoleScreenBufferInfo(h_console: windows.HANDLE, info: *windows.CONSOLE_SCREEN_BUFFER_INFO) callconv(windows.WINAPI) windows.BOOL;
     pub extern "kernel32" fn SetConsoleTextAttribute(h_console: windows.HANDLE, attrib: windows.DWORD) callconv(windows.WINAPI) windows.BOOL;         
-} else undefined;
+};
 
 pub const Fg = enum {
     Black,
@@ -168,22 +168,14 @@ const WinConWriter = struct {
     }   
 };
 
-fn targetWriterImpl() type {
-    if (targeting_windows) {
-        return union(enum) {
-            Plain: PlainWriter,
-            Ansi: AnsiWriter,
-            WinCon: WinConWriter,
-        };
-    } else {
-        return union(enum) {
-            Plain: PlainWriter,
-            Ansi: AnsiWriter,
-        };
-    }
-}
-
-const WriterImpl = targetWriterImpl();
+const WriterImpl = if (targeting_windows) union(enum) {
+    Plain: PlainWriter,
+    Ansi: AnsiWriter,
+    WinCon: WinConWriter,
+} else union(enum) {
+    Plain: PlainWriter,
+    Ansi: AnsiWriter,
+};
 
 pub const OutputWriter = struct {
     impl: WriterImpl,


### PR DESCRIPTION
Detecting if output supports ANSI color codes and falling back to Console API. This should fix https://github.com/zigtools/zls/issues/188
Not sure about quality of parts which differ between platforms though. Linux build was tested under WSL.