### PR TITLE
Fix askSelectOne rejecting max length option on Windows

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -73,7 +73,7 @@ pub fn askSelectOne(prompt: []const u8, comptime options: type) !options {
     }
 
     while (true) {
-        var buffer: [max_size + 1]u8 = undefined;
+        var buffer: [max_size + 2]u8 = undefined;
 
         try out.writeSeq(.{ Fg.DarkGray, "\n>", " " });
 


### PR DESCRIPTION
This increases the length of the `askSelectOne` input buffer by one to leave room for the Windows "\r\n" line ending.