### PR TITLE
Use bold/underline formatting instead of colors for ANSI terminals

### DIFF
--- a/src/ansi.zig
+++ b/src/ansi.zig
@@ -20,10 +20,14 @@ pub const LightBlue    = "94";
 pub const LightMagenta = "95";
 pub const LightCyan    = "96";
 pub const White        = "97";
+
+pub const ResetText    = "0";
+pub const Bold         = "1";
+pub const Underline    = "4";
 // zig fmt: on
 
 pub fn Reset() []const u8 {
-    return escape("0m");
+    return escape(ResetText ++ "m");
 }
 
 pub fn Foreground(comptime color: []const u8) []const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,7 @@ pub fn askString(allocator: std.mem.Allocator, prompt: []const u8, max_size: usi
     const in = std.io.getStdIn().reader();
     const out = OutputWriter.init(std.io.getStdOut());
 
-    try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt });
+    try out.writeSeq(.{ Fg.Bold, "? ", Fg.Reset, prompt });
 
     const result = try in.readUntilDelimiterAlloc(allocator, '\n', max_size);
     return if (std.mem.endsWith(u8, result, "\r")) result[0..(result.len - 1)] else result;
@@ -38,6 +38,7 @@ pub fn askDirPath(allocator: std.mem.Allocator, prompt: []const u8, max_size: us
     }
 }
 
+
 pub fn askBool(prompt: []const u8) !bool {
     const in = std.io.getStdIn().reader();
     const out = OutputWriter.init(std.io.getStdOut());
@@ -45,7 +46,7 @@ pub fn askBool(prompt: []const u8) !bool {
     var buffer: [1]u8 = undefined;
 
     while (true) {
-        try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.DarkGray, " (y/n) > " });
+        try out.writeSeq(.{ Fg.Bold, "? ", Fg.Reset, prompt, Fg.Bold, " (y/n) > " });
 
         const read = in.read(&buffer) catch continue;
         try in.skipUntilDelimiterOrEof('\n');
@@ -64,7 +65,7 @@ pub fn askSelectOne(prompt: []const u8, comptime options: type) !options {
     const in = std.io.getStdIn().reader();
     const out = OutputWriter.init(std.io.getStdOut());
 
-    try out.writeSeq(.{ Fg.Cyan, "? ", Fg.White, prompt, Fg.DarkGray, " (select one)", "\n\n" });
+    try out.writeSeq(.{ Fg.Bold, "? ", Fg.Reset, prompt, Fg.Bold, " (select one)", "\n\n" });
 
     comptime var max_size: usize = 0;
     inline for (@typeInfo(options).Enum.fields) |option| {

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -20,6 +20,7 @@ pub const Fg = enum {
     Magenta,
     Cyan,
     LightGray,
+    Default,
     DarkGray,
     LightRed,
     LightGreen,
@@ -28,6 +29,10 @@ pub const Fg = enum {
     LightMagenta,
     LightCyan,
     White,
+    // Those are for formatting rather than color
+    Reset,
+    Bold,
+    Underline
 };
 
 /// Ignores color specifications
@@ -95,6 +100,7 @@ const AnsiWriter = struct {
             Fg.Cyan => ansi.Foreground(ansi.Cyan),
             Fg.LightGray => ansi.Foreground(ansi.LightGray),
             Fg.DarkGray => ansi.Foreground(ansi.DarkGray),
+            Fg.Default => ansi.Foreground(ansi.Default),
             Fg.LightRed => ansi.Foreground(ansi.LightRed),
             Fg.LightGreen => ansi.Foreground(ansi.LightGreen),
             Fg.LightYellow => ansi.Foreground(ansi.LightYellow),
@@ -102,6 +108,9 @@ const AnsiWriter = struct {
             Fg.LightMagenta => ansi.Foreground(ansi.LightMagenta),
             Fg.LightCyan => ansi.Foreground(ansi.LightCyan),
             Fg.White => ansi.Foreground(ansi.White),
+            Fg.Reset => ansi.Foreground(ansi.ResetText),
+            Fg.Bold => ansi.Foreground(ansi.Bold),
+            Fg.Underline => ansi.Foreground(ansi.Underline),
         };
     }
 };


### PR DESCRIPTION
This changes the formatting on prompts to avoid color issues.

Closes #9.